### PR TITLE
Fix FC to bit-exact output (issue #9)

### DIFF
--- a/librocketnpu/src/rnpu_model.c
+++ b/librocketnpu/src/rnpu_model.c
@@ -1161,7 +1161,7 @@ rnpu_model_t *rnpu_model_load(int fd, const char *tflite_path)
       bool is_conv = (top->builtin_code == TFLITE_OP_CONV_2D ||
                       top->builtin_code == TFLITE_OP_DEPTHWISE_CONV_2D);
       bool is_fc_hw = (top->builtin_code == TFLITE_OP_FULLY_CONNECTED &&
-                       getenv("RNPU_FC_HW"));
+                       !getenv("RNPU_FC_SW"));
       if (is_conv || is_fc_hw) {
          const struct rnpu_tfl_tensor *wt = &m->tfl.tensors[top->inputs[1]];
          if (wt->quant.scales && wt->quant.num_scales > 1) {
@@ -1274,9 +1274,7 @@ rnpu_model_t *rnpu_model_load(int fd, const char *tflite_path)
          m->op_count++;
          break;
       case TFLITE_OP_FULLY_CONNECTED: {
-         if (!getenv("RNPU_FC_HW")) {
-            /* Default: SW path until HW per-channel accuracy is fixed (issue #9).
-             * Enable HW with RNPU_FC_HW=1. */
+         if (getenv("RNPU_FC_SW")) {
             lower_fully_connected(m, top, op);
             m->op_count++;
             break;

--- a/librocketnpu/src/rnpu_regcmd.c
+++ b/librocketnpu/src/rnpu_regcmd.c
@@ -29,8 +29,12 @@ static void emit_raw(uint64_t **p, uint32_t target, uint32_t reg, uint32_t value
    *(*p)++ = v;
 }
 
+static int _dump_regcmd = -1;
 static void emit(uint64_t **p, uint32_t reg, uint32_t value)
 {
+   if (_dump_regcmd == -1) _dump_regcmd = getenv("RNPU_DUMP_REGCMD") != NULL;
+   if (_dump_regcmd)
+      fprintf(stderr, "  EMIT reg=0x%04x val=0x%08x\n", reg, value);
    emit_raw(p, rkt_get_target(reg) + 0x1, reg, value);
 }
 
@@ -79,7 +83,7 @@ static unsigned fill_standard_regcmd(const struct rnpu_model *model,
    if (op->fc_1x1) {
       /* FC 1×1 spatial: RKNN-discovered DMA config. CHANNEL_REAL=63 splits
        * 3072 channels into 48 slices of 64, enabling sequential channel reads. */
-      EMIT(REG_CNA_CONV_CON2, CNA_CONV_CON2_FEATURE_GRAINS(32));
+      EMIT(REG_CNA_CONV_CON2, 0x20);  /* RKNN FC value */
       EMIT(REG_CNA_CONV_CON3, 0x09);
       EMIT(REG_CNA_DATA_SIZE0, CNA_DATA_SIZE0_DATAIN_WIDTH(1) |
                                 CNA_DATA_SIZE0_DATAIN_HEIGHT(1));
@@ -96,13 +100,16 @@ static unsigned fill_standard_regcmd(const struct rnpu_model *model,
    }
    EMIT(REG_CNA_DATA_SIZE2, CNA_DATA_SIZE2_DATAOUT_WIDTH(task->output_width));
    EMIT(REG_CNA_DATA_SIZE3, CNA_DATA_SIZE3_DATAOUT_ATOMICS(task->atomic_count));
-   EMIT(REG_CNA_WEIGHT_SIZE0, task->weights_width * task->weights_height *
-                               task->input_channels * task->weights_kernels);
-   EMIT(REG_CNA_WEIGHT_SIZE1, task->weights_width * task->weights_height *
-                               task->input_channels);
-   EMIT(REG_CNA_WEIGHT_SIZE2, CNA_WEIGHT_SIZE2_WEIGHT_WIDTH(task->weights_width) |
-                               CNA_WEIGHT_SIZE2_WEIGHT_HEIGHT(task->weights_height) |
-                               CNA_WEIGHT_SIZE2_WEIGHT_KERNELS(task->weights_kernels));
+   {  /* FC 1×1: RKNN uses actual OC for weight size, not padded */
+      unsigned wk = op->fc_1x1 ? task->output_channels_real : task->weights_kernels;
+      EMIT(REG_CNA_WEIGHT_SIZE0, task->weights_width * task->weights_height *
+                                  task->input_channels * wk);
+      EMIT(REG_CNA_WEIGHT_SIZE1, task->weights_width * task->weights_height *
+                                  task->input_channels);
+      EMIT(REG_CNA_WEIGHT_SIZE2, CNA_WEIGHT_SIZE2_WEIGHT_WIDTH(task->weights_width) |
+                                  CNA_WEIGHT_SIZE2_WEIGHT_HEIGHT(task->weights_height) |
+                                  CNA_WEIGHT_SIZE2_WEIGHT_KERNELS(wk));
+   }
    EMIT(REG_CNA_CBUF_CON0, con0);
    EMIT(REG_CNA_CBUF_CON1, CNA_CBUF_CON1_DATA_ENTRIES(task->input_data_entries));
 
@@ -392,13 +399,16 @@ static unsigned fill_per_channel_regcmd(const struct rnpu_model *model,
                              CNA_DATA_SIZE1_DATAIN_CHANNEL(task->input_channels));
    EMIT(REG_CNA_DATA_SIZE2, CNA_DATA_SIZE2_DATAOUT_WIDTH(task->output_width));
    EMIT(REG_CNA_DATA_SIZE3, CNA_DATA_SIZE3_DATAOUT_ATOMICS(task->atomic_count));
-   EMIT(REG_CNA_WEIGHT_SIZE0, task->weights_width * task->weights_height *
-                               task->input_channels * task->weights_kernels);
-   EMIT(REG_CNA_WEIGHT_SIZE1, task->weights_width * task->weights_height *
-                               task->input_channels);
-   EMIT(REG_CNA_WEIGHT_SIZE2, CNA_WEIGHT_SIZE2_WEIGHT_WIDTH(task->weights_width) |
-                               CNA_WEIGHT_SIZE2_WEIGHT_HEIGHT(task->weights_height) |
-                               CNA_WEIGHT_SIZE2_WEIGHT_KERNELS(task->weights_kernels));
+   {  /* FC 1×1: RKNN uses actual OC for weight size, not padded */
+      unsigned wk = op->fc_1x1 ? task->output_channels_real : task->weights_kernels;
+      EMIT(REG_CNA_WEIGHT_SIZE0, task->weights_width * task->weights_height *
+                                  task->input_channels * wk);
+      EMIT(REG_CNA_WEIGHT_SIZE1, task->weights_width * task->weights_height *
+                                  task->input_channels);
+      EMIT(REG_CNA_WEIGHT_SIZE2, CNA_WEIGHT_SIZE2_WEIGHT_WIDTH(task->weights_width) |
+                                  CNA_WEIGHT_SIZE2_WEIGHT_HEIGHT(task->weights_height) |
+                                  CNA_WEIGHT_SIZE2_WEIGHT_KERNELS(wk));
+   }
    EMIT(REG_CNA_CBUF_CON0, con0);
    EMIT(REG_CNA_CBUF_CON1, CNA_CBUF_CON1_DATA_ENTRIES(task->input_data_entries));
    EMIT(REG_CNA_CVT_CON0, CNA_CVT_CON0_DATA_SIGN(1) | CNA_CVT_CON0_CVT_TYPE(1) |
@@ -609,13 +619,16 @@ static unsigned fill_hybrid_regcmd(const struct rnpu_model *model,
                              CNA_DATA_SIZE1_DATAIN_CHANNEL(task->input_channels));
    EMIT(REG_CNA_DATA_SIZE2, CNA_DATA_SIZE2_DATAOUT_WIDTH(task->output_width));
    EMIT(REG_CNA_DATA_SIZE3, CNA_DATA_SIZE3_DATAOUT_ATOMICS(task->atomic_count));
-   EMIT(REG_CNA_WEIGHT_SIZE0, task->weights_width * task->weights_height *
-                               task->input_channels * task->weights_kernels);
-   EMIT(REG_CNA_WEIGHT_SIZE1, task->weights_width * task->weights_height *
-                               task->input_channels);
-   EMIT(REG_CNA_WEIGHT_SIZE2, CNA_WEIGHT_SIZE2_WEIGHT_WIDTH(task->weights_width) |
-                               CNA_WEIGHT_SIZE2_WEIGHT_HEIGHT(task->weights_height) |
-                               CNA_WEIGHT_SIZE2_WEIGHT_KERNELS(task->weights_kernels));
+   {  /* FC 1×1: RKNN uses actual OC for weight size, not padded */
+      unsigned wk = op->fc_1x1 ? task->output_channels_real : task->weights_kernels;
+      EMIT(REG_CNA_WEIGHT_SIZE0, task->weights_width * task->weights_height *
+                                  task->input_channels * wk);
+      EMIT(REG_CNA_WEIGHT_SIZE1, task->weights_width * task->weights_height *
+                                  task->input_channels);
+      EMIT(REG_CNA_WEIGHT_SIZE2, CNA_WEIGHT_SIZE2_WEIGHT_WIDTH(task->weights_width) |
+                                  CNA_WEIGHT_SIZE2_WEIGHT_HEIGHT(task->weights_height) |
+                                  CNA_WEIGHT_SIZE2_WEIGHT_KERNELS(wk));
+   }
    EMIT(REG_CNA_CBUF_CON0, con0);
    EMIT(REG_CNA_CBUF_CON1, CNA_CBUF_CON1_DATA_ENTRIES(task->input_data_entries));
 
@@ -961,7 +974,7 @@ static unsigned fill_brdma_per_channel_regcmd(const struct rnpu_model *model,
    if (op->fc_1x1) {
       /* FC 1×1 spatial: RKNN-discovered DMA config. CHANNEL_REAL=63 splits
        * 3072 channels into 48 slices of 64, enabling sequential channel reads. */
-      EMIT(REG_CNA_CONV_CON2, CNA_CONV_CON2_FEATURE_GRAINS(32));
+      EMIT(REG_CNA_CONV_CON2, 0x20);  /* RKNN FC value */
       EMIT(REG_CNA_CONV_CON3, 0x09);
       EMIT(REG_CNA_DATA_SIZE0, CNA_DATA_SIZE0_DATAIN_WIDTH(1) |
                                 CNA_DATA_SIZE0_DATAIN_HEIGHT(1));
@@ -978,13 +991,16 @@ static unsigned fill_brdma_per_channel_regcmd(const struct rnpu_model *model,
    }
    EMIT(REG_CNA_DATA_SIZE2, CNA_DATA_SIZE2_DATAOUT_WIDTH(task->output_width));
    EMIT(REG_CNA_DATA_SIZE3, CNA_DATA_SIZE3_DATAOUT_ATOMICS(task->atomic_count));
-   EMIT(REG_CNA_WEIGHT_SIZE0, task->weights_width * task->weights_height *
-                               task->input_channels * task->weights_kernels);
-   EMIT(REG_CNA_WEIGHT_SIZE1, task->weights_width * task->weights_height *
-                               task->input_channels);
-   EMIT(REG_CNA_WEIGHT_SIZE2, CNA_WEIGHT_SIZE2_WEIGHT_WIDTH(task->weights_width) |
-                               CNA_WEIGHT_SIZE2_WEIGHT_HEIGHT(task->weights_height) |
-                               CNA_WEIGHT_SIZE2_WEIGHT_KERNELS(task->weights_kernels));
+   {  /* FC 1×1: RKNN uses actual OC for weight size, not padded */
+      unsigned wk = op->fc_1x1 ? task->output_channels_real : task->weights_kernels;
+      EMIT(REG_CNA_WEIGHT_SIZE0, task->weights_width * task->weights_height *
+                                  task->input_channels * wk);
+      EMIT(REG_CNA_WEIGHT_SIZE1, task->weights_width * task->weights_height *
+                                  task->input_channels);
+      EMIT(REG_CNA_WEIGHT_SIZE2, CNA_WEIGHT_SIZE2_WEIGHT_WIDTH(task->weights_width) |
+                                  CNA_WEIGHT_SIZE2_WEIGHT_HEIGHT(task->weights_height) |
+                                  CNA_WEIGHT_SIZE2_WEIGHT_KERNELS(wk));
+   }
    EMIT(REG_CNA_CBUF_CON0, con0);
    EMIT(REG_CNA_CBUF_CON1, CNA_CBUF_CON1_DATA_ENTRIES(task->input_data_entries));
 
@@ -1088,7 +1104,9 @@ static unsigned fill_brdma_per_channel_regcmd(const struct rnpu_model *model,
                                DPU_BS_OW_CFG_SIZE_E_1(1) |
                                DPU_BS_OW_CFG_SIZE_E_0(1));
    }
-   EMIT(REG_DPU_BS_OW_OP, DPU_BS_OW_OP_OW_OP(task->output_channels - 1));
+   /* RKNN uses OW_OP=0 for FC (int8 weights, no zero-point correction) */
+   EMIT(REG_DPU_BS_OW_OP, DPU_BS_OW_OP_OW_OP(
+      op->fc_1x1 ? 0 : task->output_channels - 1));
    EMIT(REG_DPU_WDMA_SIZE_0, DPU_WDMA_SIZE_0_CHANNEL_WDMA(task->output_channels - 1));
    EMIT(REG_DPU_WDMA_SIZE_1, DPU_WDMA_SIZE_1_HEIGHT_WDMA(task->output_height - 1) |
                               DPU_WDMA_SIZE_1_WIDTH_WDMA(task->output_width - 1));
@@ -1269,7 +1287,7 @@ static unsigned fill_brdma_continuation_regcmd(const struct rnpu_model *model,
    if (op->fc_1x1) {
       /* FC 1×1 spatial: RKNN-discovered DMA config. CHANNEL_REAL=63 splits
        * 3072 channels into 48 slices of 64, enabling sequential channel reads. */
-      EMIT(REG_CNA_CONV_CON2, CNA_CONV_CON2_FEATURE_GRAINS(32));
+      EMIT(REG_CNA_CONV_CON2, 0x20);  /* RKNN FC value */
       EMIT(REG_CNA_CONV_CON3, 0x09);
       EMIT(REG_CNA_DATA_SIZE0, CNA_DATA_SIZE0_DATAIN_WIDTH(1) |
                                 CNA_DATA_SIZE0_DATAIN_HEIGHT(1));
@@ -1286,13 +1304,16 @@ static unsigned fill_brdma_continuation_regcmd(const struct rnpu_model *model,
    }
    EMIT(REG_CNA_DATA_SIZE2, CNA_DATA_SIZE2_DATAOUT_WIDTH(task->output_width));
    EMIT(REG_CNA_DATA_SIZE3, CNA_DATA_SIZE3_DATAOUT_ATOMICS(task->atomic_count));
-   EMIT(REG_CNA_WEIGHT_SIZE0, task->weights_width * task->weights_height *
-                               task->input_channels * task->weights_kernels);
-   EMIT(REG_CNA_WEIGHT_SIZE1, task->weights_width * task->weights_height *
-                               task->input_channels);
-   EMIT(REG_CNA_WEIGHT_SIZE2, CNA_WEIGHT_SIZE2_WEIGHT_WIDTH(task->weights_width) |
-                               CNA_WEIGHT_SIZE2_WEIGHT_HEIGHT(task->weights_height) |
-                               CNA_WEIGHT_SIZE2_WEIGHT_KERNELS(task->weights_kernels));
+   {  /* FC 1×1: RKNN uses actual OC for weight size, not padded */
+      unsigned wk = op->fc_1x1 ? task->output_channels_real : task->weights_kernels;
+      EMIT(REG_CNA_WEIGHT_SIZE0, task->weights_width * task->weights_height *
+                                  task->input_channels * wk);
+      EMIT(REG_CNA_WEIGHT_SIZE1, task->weights_width * task->weights_height *
+                                  task->input_channels);
+      EMIT(REG_CNA_WEIGHT_SIZE2, CNA_WEIGHT_SIZE2_WEIGHT_WIDTH(task->weights_width) |
+                                  CNA_WEIGHT_SIZE2_WEIGHT_HEIGHT(task->weights_height) |
+                                  CNA_WEIGHT_SIZE2_WEIGHT_KERNELS(wk));
+   }
    EMIT(REG_CNA_CBUF_CON0, con0);
    EMIT(REG_CNA_CBUF_CON1, CNA_CBUF_CON1_DATA_ENTRIES(task->input_data_entries));
 


### PR DESCRIPTION
## Summary

Achieve **bit-exact** FC output (10/10 exact, max_diff=0) by matching RKNN vendor register values discovered via intercept.

### Register fixes

| Register | Before | After (RKNN) | Impact |
|---|---|---|---|
| CONV_CON2 | `FEATURE_GRAINS(32)` = 0x200 | **0x20** | Was 16× too large due to 4-bit shift in macro |
| WEIGHT_SIZE0/2 | padded OC (32) | **actual OC (10)** | Correct weight tensor size |
| BS_OW_OP | output_channels-1 (31) | **0** | No OW compensation for int8 BRDMA |

### Root cause

`CNA_CONV_CON2_FEATURE_GRAINS` macro has a 4-bit shift (`__SHIFT=4`), so `FEATURE_GRAINS(32) = 32 << 4 = 0x200`. RKNN's raw register value `0x20` means `FEATURE_GRAINS = 0x20 >> 4 = 2`. Using the macro with value 32 produced 512 instead of the intended 32, causing the DMA to read input data in the wrong pattern.

### Test results

- [x] FC BRDMA: **10/10 exact, max_diff=0** (was max_diff=70)
- [x] MBv1: class 653, confidence 230/255

Fixes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)