### PR TITLE
QEMU: fix FC 1×1 conv emulation (issue #4)

### DIFF
--- a/qemu/ci_run_tests.sh
+++ b/qemu/ci_run_tests.sh
@@ -134,18 +134,18 @@ else
     echo "SKIP: MobileNetV1 result not found"
 fi
 
-# Check FC test
-# TODO: FC now runs on NPU HW (1x1 conv), but QEMU conv accuracy diverges from
-# real HW (same root cause as MobileNetV1, see issue #2). Downgrade to WARN
-# until QEMU conv engine is fixed.
+# Check FC test — enforced for Rocket, warned for vendor (BRDMA emulation gap)
 if grep -q "FC test exit code:" "$LOG"; then
     FC_EXIT=$(grep "FC test exit code:" "$LOG" | tail -1 | tr -d '\r' | awk '{print $NF}')
     if [ "$FC_EXIT" = "0" ]; then
         FC_RESULT=$(grep "RESULT:.*bit-exact\|RESULT:.*max_diff\|RESULT:.*FAIL" "$LOG" | tail -1)
         echo "PASS: FC test — $FC_RESULT"
+    elif [ "$VARIANT" = "rocket" ]; then
+        echo "FAIL: FC test exited with code $FC_EXIT"
+        FAILED=1
     else
         FC_RESULT=$(grep "RESULT:" "$LOG" | tail -1)
-        echo "WARN: FC test — $FC_RESULT (not enforced, see issue #2)"
+        echo "WARN: FC test — $FC_RESULT (vendor kernel, not enforced)"
     fi
 else
     echo "SKIP: FC test not found in output"

--- a/qemu/hw/misc/rockchip-npu.c
+++ b/qemu/hw/misc/rockchip-npu.c
@@ -336,7 +336,10 @@ static void execute_convolution(RockchipNPUState *s, RocketNPUCore *core,
     uint32_t out_w = task->output_width;
     uint32_t out_h = task->output_height;
     uint32_t out_c = task->output_channels;
-    uint32_t in_c_real = task->input_channels_real;
+    /* FC 1×1 mode: DATAIN_CHANNEL_REAL encodes slice size (64), not actual IC.
+     * Use full input_channels for computation when CHANNEL_REAL < CHANNEL. */
+    bool fc_1x1 = (task->input_channels_real < task->input_channels);
+    uint32_t in_c_real = fc_1x1 ? task->input_channels : task->input_channels_real;
     uint32_t in_c = task->input_channels;
     uint32_t filt_w = task->weight_width;
     uint32_t filt_h = task->weight_height;
@@ -356,9 +359,15 @@ static void execute_convolution(RockchipNPUState *s, RocketNPUCore *core,
     uint32_t in_line_bytes = task->input_line_stride
         ? task->input_line_stride * 4
         : in_h * NPU_FEATURE_ATOMIC_SIZE;
-    uint32_t in_surf_bytes = task->input_surface_stride
-        ? task->input_surface_stride * 4
-        : in_w * in_line_bytes;
+    uint32_t in_surf_bytes;
+    if (fc_1x1) {
+        /* FC 1×1: surfaces are contiguous (16 bytes each for 1×1 spatial) */
+        in_surf_bytes = in_w * in_line_bytes;
+    } else {
+        in_surf_bytes = task->input_surface_stride
+            ? task->input_surface_stride * 4
+            : in_w * in_line_bytes;
+    }
     uint32_t in_buf_size = (in_groups > 1)
         ? (in_groups - 1) * in_surf_bytes + (in_w - 1) * in_line_bytes
           + in_h * NPU_FEATURE_ATOMIC_SIZE


### PR DESCRIPTION
## Summary

Fix QEMU NPU emulator to handle the fc_1x1 register mode where
`DATAIN_CHANNEL_REAL` (64) differs from `DATAIN_CHANNEL` (3072).

### Problem

The emulator used `input_channels_real` as the inner loop limit for
the convolution computation. With fc_1x1 registers, this is 64
instead of the actual 3072 input channels, causing 2968 channels
to be skipped.

### Fix

When `input_channels_real < input_channels`, use the full count:
```c
uint32_t in_c_real = (task->input_channels_real < task->input_channels)
    ? task->input_channels : task->input_channels_real;
```

### Expected results

- FC QEMU test: should produce bit-exact or near-exact output (was max_diff=59)
- Conv tests 9/9: no regression
- MobileNetV1: no regression (CHANNEL_REAL == CHANNEL for standard convs)

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)