### PR TITLE
ci: run all checks on every PR for branch protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,6 @@ on:
       - 'librocketnpu/**'
       - '.github/workflows/ci.yml'
   pull_request:
-    paths:
-      - 'librocketnpu/**'
-      - '.github/workflows/ci.yml'
 
 defaults:
   run:

--- a/.github/workflows/qemu.yml
+++ b/.github/workflows/qemu.yml
@@ -9,11 +9,6 @@ on:
       - 'librocketnpu/**'
       - '.github/workflows/qemu.yml'
   pull_request:
-    paths:
-      - 'qemu/**'
-      - 'qemu-boot/**'
-      - 'librocketnpu/**'
-      - '.github/workflows/qemu.yml'
 
 jobs:
   qemu-npu-test:


### PR DESCRIPTION
Remove paths filter from PR triggers so branch protection required checks always run.