### PR TITLE
qemu: fix BS_OW_OP for BRDMA accuracy (issue #13)

### DIFF
--- a/qemu/hw/misc/rockchip-npu.c
+++ b/qemu/hw/misc/rockchip-npu.c
@@ -494,8 +494,10 @@ static void execute_convolution(RockchipNPUState *s, RocketNPUCore *core,
 
                 /* BS_OW_OP: weight zero-point compensation (SDP stage).
                  * Applied AFTER CACC truncation, matching hardware pipeline order.
-                 * Weights stored as (w - 0x80), BS_OW_OP = (0x80 - wzp) corrects. */
-                if (task->bs_ow_op) {
+                 * Weights stored as (w - 0x80), BS_OW_OP = (0x80 - wzp) corrects.
+                 * Only applied when OW_SRC=0 (scalar). When OW_SRC=1 (DMA),
+                 * the register value is a channel count, not a scalar operand. */
+                if (task->bs_ow_op && !(task->bs_ow_cfg & 1)) {
                     int16_t ow_op = (int16_t)task->bs_ow_op;
                     acc += (int32_t)ow_op * sum_inputs;
                 }


### PR DESCRIPTION
Skip BS_OW_OP scalar multiplication when OW_SRC=DMA (bit 0 of BS_OW_CFG).

RKNN uses OW_SRC=1 with OW_OP=31, which the emulator incorrectly
applied as `31 × Σinputs`, corrupting the accumulator. On real HW,
OW_SRC=1 means the value comes from DMA, not the scalar register.

| RKNN FC test | Before | After (expected) |
|---|---|---|
| Real HW | max_diff=57 | 57 (unchanged) |
| QEMU vendor | max_diff=80 | ~57 (matching real HW) |

Fixes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)