### PR TITLE
qemu: fix vendor FC weight indexing (issue #13)

### DIFF
--- a/qemu/hw/misc/rockchip-npu.c
+++ b/qemu/hw/misc/rockchip-npu.c
@@ -503,9 +503,13 @@ static void execute_convolution(RockchipNPUState *s, RocketNPUCore *core,
                                                     kx, ky, filt_w, filt_h,
                                                     in_c_real, 1, true);
                             } else {
-                                w_val = read_weight(wt_buf, oc, abs_ic,
-                                                    kx, ky, filt_w, filt_h,
-                                                    in_c_real, out_c, false);
+                                /* Padded channels beyond wt_oc have zero weight */
+                                if (oc >= wt_oc)
+                                    w_val = 0;
+                                else
+                                    w_val = read_weight(wt_buf, oc, abs_ic,
+                                                        kx, ky, filt_w, filt_h,
+                                                        in_c_real, wt_oc, false);
                             }
 
                             acc += (int32_t)in_val * (int32_t)w_val;


### PR DESCRIPTION
## Summary
- Fix weight indexing for ops where `output_channels_real < output_channels` (e.g., FC with 10 real channels padded to 32)
- librocketnpu packs weights using only the real channel count, but QEMU used the padded count as stride — reading from wrong offsets
- Zero-pad weights for channels beyond `output_channels_real`
- Remove leftover fused MUL+CVT code, add BRDMA OW_OP N-1 correction

## Results
- **Vendor FC: max_diff 80 → 1** (near bit-exact)
- Rocket: no change (12/12, MBv1 class 653, FC bit-exact)
- Real HW: no regression (MBv1 max_diff=1, FC bit-exact)

Closes #13

## Test plan
- [x] `ci_run_tests.sh rocket` — 12/12, MBv1 653, FC bit-exact
- [x] `ci_run_tests.sh vendor` — FC max_diff=1 (was 80)
- [x] Real HW (board): MBv1 max_diff=1, FC bit-exact

🤖 Generated with [Claude Code](https://claude.com/claude-code)