### PR TITLE
librocketnpu: BRDMA per-channel requant on all spatial tiles

### DIFF
--- a/librocketnpu/src/rnpu_model.c
+++ b/librocketnpu/src/rnpu_model.c
@@ -856,12 +856,9 @@ static void compile_regcmds(struct rnpu_model *m)
          rc_offset += ALIGN_UP(size_bytes, 64);
       }
 
-      /* Patch chain pointers between tasks within this op.
-       * BRDMA ops: skip chaining — each task submitted as separate job. */
-      if (!op->use_brdma_per_channel) {
-         for (unsigned t = 0; t < op->task_count - 1; t++)
-            patch_chain(m, op, t, op, t + 1);
-      }
+      /* Patch chain pointers between tasks within this op. */
+      for (unsigned t = 0; t < op->task_count - 1; t++)
+         patch_chain(m, op, t, op, t + 1);
    }
 
    /* Third pass: patch cross-operation chain pointers for RKNPU batching.
@@ -899,6 +896,8 @@ static bool can_merge_rknpu(struct rnpu_model *m, unsigned i)
       return false;
    if (a->output_tensor_channels == 0 || b->output_tensor_channels == 0)
       return false;
+   if (a->use_brdma_per_channel || b->use_brdma_per_channel)
+      return false;
    return a->output_tensor == b->output_tensor;
 }
 
@@ -917,19 +916,14 @@ static void build_execution_plan(struct rnpu_model *m)
    m->segment_count = ns;
 
    /* Count HW resources.
-    * BRDMA ops: 1 job per task (can't chain BRDMA tasks on RKNPU).
-    * Standard ops: merge per-channel groups into one job. */
+    * Standard + BRDMA ops: 1 multi-task job per op, merge per-channel groups. */
    unsigned total_jobs = 0, total_tasks = 0;
    for (unsigned i = 0; i < m->op_count; i++) {
       if (m->ops[i].type == RNPU_OP_CONV) {
          total_tasks += m->ops[i].task_count;
-         if (m->ops[i].use_brdma_per_channel) {
-            total_jobs += m->ops[i].task_count;
-         } else {
-            total_jobs++;
-            while (can_merge_rknpu(m, i))
-               { total_tasks += m->ops[i + 1].task_count; i++; }
-         }
+         total_jobs++;
+         while (can_merge_rknpu(m, i))
+            { total_tasks += m->ops[i + 1].task_count; i++; }
       }
    }
 
@@ -946,33 +940,8 @@ static void build_execution_plan(struct rnpu_model *m)
       if (m->ops[i].type != RNPU_OP_CONV) continue;
       struct rnpu_operation *cur = &m->ops[i];
 
-      if (cur->use_brdma_per_channel) {
-         /* BRDMA: each task is a separate 1-task job */
-         for (unsigned t = 0; t < cur->task_count; t++) {
-            m->hw_tasks[ti].regcmd = cur->tasks[t].regcfg_addr;
-            m->hw_tasks[ti].regcmd_count = cur->tasks[t].regcfg_amount;
-
-            unsigned hi = ji * handles_per_job;
-            m->in_handles[hi] = m->weight_bo.handle;
-            m->in_handles[hi + 1] = m->regcmd_bo.handle;
-            m->in_handles[hi + 2] = m->bias_bo.handle ? m->bias_bo.handle : m->weight_bo.handle;
-            if (handles_per_job > 3)
-               m->in_handles[hi + 3] = m->brdma_bo.handle;
-            m->out_handles[ji] = m->activation_bo.handle;
-
-            struct drm_rocket_job *job = &m->jobs[ji];
-            job->task_struct_size = sizeof(struct drm_rocket_task);
-            job->tasks = (uint64_t)(uintptr_t)&m->hw_tasks[ti];
-            job->task_count = 1;
-            job->in_bo_handles = (uint64_t)(uintptr_t)&m->in_handles[hi];
-            job->in_bo_handle_count = handles_per_job;
-            job->out_bo_handles = (uint64_t)(uintptr_t)&m->out_handles[ji];
-            job->out_bo_handle_count = 1;
-            ji++;
-            ti++;
-         }
-      } else {
-         /* Standard: multi-task job with chain pointers */
+      {
+         /* Multi-task job with chain pointers (standard + BRDMA) */
          unsigned first_task = ti;
          unsigned merged_task_count = 0;
          unsigned j = i;
@@ -1020,11 +989,8 @@ static void build_execution_plan(struct rnpu_model *m)
          seg->op_count = 0;
          unsigned seg_jobs = 0;
          while (i < m->op_count && m->ops[i].type == RNPU_OP_CONV) {
-            if (m->ops[i].use_brdma_per_channel) {
-               seg_jobs += m->ops[i].task_count;
-            } else if (seg->op_count == 0 || !can_merge_rknpu(m, i - 1)) {
+            if (seg->op_count == 0 || !can_merge_rknpu(m, i - 1))
                seg_jobs++;
-            }
             seg->op_count++;
             i++;
          }

--- a/librocketnpu/src/rnpu_regcmd.c
+++ b/librocketnpu/src/rnpu_regcmd.c
@@ -1451,15 +1451,11 @@ unsigned rnpu_fill_regcmd(const struct rnpu_model *model,
                           unsigned task_num)
 {
    /* RKNPU full-conv per-channel: uses BRDMA with bias+MUL DMA data.
-    * Only the initial tasks (before weight reuse kicks in) get the full
-    * BRDMA regcmd. Continuation tasks (weight reuse) use standard regcmd
-    * — matching RKNN's behavior where spatial splits have BS_CFG=0. */
-   if (rnpu_active_driver == RNPU_DRIVER_RKNPU && op->use_brdma_per_channel) {
-      if (task_num == 0 || !op->reuse_weights_cbuf)
-         return fill_brdma_per_channel_regcmd(model, op, dst, task_num);
-      else
-         return fill_standard_regcmd(model, op, dst, task_num);
-   }
+    * ALL spatial tiles (including continuation with weight reuse) use the
+    * full BRDMA regcmd — the hardware requires complete DPU configuration
+    * in every chained task (no sticky state through chain pointers). */
+   if (rnpu_active_driver == RNPU_DRIVER_RKNPU && op->use_brdma_per_channel)
+      return fill_brdma_per_channel_regcmd(model, op, dst, task_num);
 
    /* For RKNPU per-channel ops (GS=1), use per-channel regcmd with
     * BN-stage bias addition — EXCEPT for ops without ReLU (e.g. FC),


### PR DESCRIPTION
## Summary
Enable BRDMA per-channel requantization on ALL spatial tiles of tiled convolutions, not just the first tile. Previously, continuation tiles fell back to per-tensor requantization, degrading YOLO accuracy significantly.

The fix uses the full BRDMA per-channel regcmd for every chained task. The hardware requires complete DPU configuration in every task — there is no "sticky state" through chain pointers despite RKNN appearing to use one.

## Results (YOLOv5s INT8 vs RKNN golden, vendor kernel)

| Output | Before (mean diff) | After (mean diff) | Before (≤5) | After (≤5) |
|--------|-------------------|-------------------|-------------|------------|
| H0 (40×40) | 26.5 | **9.4** | 50.0% | **93.9%** |
| H1 (80×80) | 22.0 | **16.3** | 3.2% | 3.0% |
| H2 (20×20) | 13.2 | **12.4** | 3.7% | 8.2% |

## Changes
- `rnpu_model.c`: Chain all ops (including BRDMA), multi-task jobs for BRDMA, fix segment counting, no cross-op merge for BRDMA
- `rnpu_regcmd.c`: Route all BRDMA spatial tiles through `fill_brdma_per_channel_regcmd`
- Net -38 lines (removed per-task BRDMA job path)

## Test plan
- [x] MBv1 latency unchanged (no BRDMA ops)
- [x] YOLO accuracy improved (H0 mean 26.5 → 9.4)
- [ ] CI passes (librocketnpu changes, no QEMU changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)