### PR TITLE
librocketnpu: actual-OC weight packing for RKNN BRDMA (issue #34)

### DIFF
--- a/librocketnpu/src/rnpu_task.c
+++ b/librocketnpu/src/rnpu_task.c
@@ -133,6 +133,8 @@ static void fill_task(struct rnpu_operation *op, struct rnpu_split_task *task)
       task->weights_kernels = 1;
    else if (op->output_channels == 1 && op->output_tensor_channels > 0)
       task->weights_kernels = 2;
+   else if (op->rknn_brdma_override)
+      task->weights_kernels = ALIGN_UP(op->output_channels, 2);
    else
       task->weights_kernels = ALIGN_UP(MAX2(op->output_channels, 32), 2);
 


### PR DESCRIPTION
## Summary
Use actual output channel count (not padded to 32) for weight kernel registers when RKNN BRDMA override is active. Matches RKNN's weight packing.

For 16 OC: `weights_kernels` was 32, now 16 (matching RKNN's WT_SIZE2).

No YOLO accuracy change (all ops have oc >= 32). Fixes register mismatch for small models.

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)