### PR TITLE
openrknn: honour rknn_set_core_mask for single-core values (partial #60)

### DIFF
--- a/openrknn/docs/benchmarks.md
+++ b/openrknn/docs/benchmarks.md
@@ -8,11 +8,14 @@ Latency comparison between openrknn's OWN mode and the vendor
 - **Single-core: parity with vendor on all 5 runtime models** (within
   noise, −0.2% to −1.5% on average latency). openrknn's from-scratch
   submit path doesn't add any measurable per-run overhead.
-- **Multi-core: openrknn loses 1.31×–1.87× on 4/5 models** because
-  `orknn_npu_submit` in `openrknn_drm.c` hardcodes `core_mask=0x0` and
-  silently ignores whatever the user sets via `rknn_set_core_mask`. The
-  mask is stored in `ctx->core_mask` but never plumbed into the
-  ioctl descriptor. Tracked by [#60][i60].
+- **`rknn_set_core_mask` is now honoured for single-core values.**
+  Users can pick Core 0 (0x1), Core 1 (0x2), or Core 2 (0x4)
+  explicitly for load balancing across concurrent processes.
+- **Multi-core values (0x3 / 0x5 / 0x6 / 0x7) fall back to Core 0
+  with a warning.** True multi-core parallelism requires parsing
+  the .rknn's pre-compiled per-core-count task BO layouts, which
+  openrknn doesn't yet do — see [#60][i60] and the "Multi-core
+  roadmap" section below.
 
 [i60]: https://github.com/widgetii/orangepi5plus-npu/issues/60
 
@@ -74,36 +77,73 @@ limitation of openrknn today. Any application that calls
 `rknn_set_core_mask(RKNN_NPU_CORE_0_1_2)` is silently getting
 single-core execution.
 
-## Why openrknn ignores the user's core_mask
+## Multi-core roadmap
 
-`rknn_set_core_mask` stores the requested mask in `ctx->core_mask`
-(see `openrknn_api.c:322`), but `orknn_npu_submit` in
-`openrknn_drm.c:270` hardcodes the ioctl descriptor's `core_mask`
-field to `0x0`:
+### Phase 1: honour single-core masks *(landed, this file)*
 
-```c
-struct rknpu_submit sub = {
-    .flags = seg->flags | RKNPU_JOB_BLOCK,
-    .task_start = seg->sc_start,
-    .task_number = seg->task_number,
-    .task_obj_addr = task_bo->obj_addr,
-    .core_mask = 0x0,   /* <-- ignores ctx->core_mask */
-    .subcore_task = {
-        { seg->sc_start, seg->sc_count },
-        { seg->sc_start, seg->sc_count },
-        { seg->sc_start, seg->sc_count },
-        { seg->sc_start, seg->sc_count },
-        { seg->sc_start, seg->sc_count },
-    },
-};
-```
+`rknn_set_core_mask` now works for `RKNN_NPU_CORE_0` (0x1),
+`RKNN_NPU_CORE_1` (0x2), and `RKNN_NPU_CORE_2` (0x4). The kernel
+reads `subcore_task[core_index]` to find the task range for the
+active core, and we populate slots [0..2] with the same
+`(sc_start, sc_count)` so any of the three works. Hardware verified
+via `/sys/kernel/debug/rknpu/load` — mask=0x2 lights up Core 1 at
+93-99%, Core 0/2 at 0%, etc.
 
-Wiring `ctx->core_mask` through to the submit isn't enough on its own:
-for a real multi-core speedup the segment needs `task_number =
-sc_count × active_cores` (the cross-core replica count) and each of
-the 5 `subcore_task` entries needs a core-specific `(task_start,
-task_count)` slice. The .rknn task BO already contains those replicas
-— we just need to map them. See [#60][i60] for the full design sketch.
+Multi-core masks (0x3, 0x5, 0x6, 0x7) log a one-time warning and
+fall back to Core 0. Set `ORKNN_ALLOW_MULTICORE=1` to force the
+submit through anyway — expect hangs or wrong outputs.
+
+### Phase 2: honest multi-core parallelism *(#60 — not landed)*
+
+The hard scope. Investigation during the bench work revealed that
+the RKNN toolkit pre-compiles **separate per-core-count task BO
+regions** into the .rknn file. For mobilenet_v1 the layout is:
+
+| Region | Size | Purpose |
+|--------|------|---------|
+| tasks 0–50    | 51 tasks | single-core execution |
+| tasks 51–131  | 81 tasks | dual-core execution (core 0 at 51–82, core 1 at 99–130, + cleanup) |
+| tasks 133–236 | 104 tasks | triple-core execution (core 0 at 133–160, core 1 at 177–204, core 2 at 207–234, + cleanup) |
+| tasks 237–306 | 70 tasks | second-cycle warmup/iter replicas |
+
+Each region has its own pre-computed regcmds with different
+task_start offsets per core. The vendor reads `subcore_task[core_index + 2]`
+for 3-core mode (slots [2..4]) and `subcore_task[core_index]` for 1/2-core
+(slots [0..2]) — this is verified in the kernel driver at
+`rknpu-driver/rknpu_job.c:320-330` (`rknpu_get_task_number` +
+`rknpu_core_index` functions).
+
+openrknn's `fb_build_segments` derives only the single-core region
+from the FB operator graph. Adding multi-core support requires:
+
+1. Reverse-engineering how the RKNN toolkit encodes per-core-count
+   regions in the task BO (or in an auxiliary FB field we don't
+   yet parse)
+2. Extending `parse_fb_operators` / `fb_build_segments` to produce
+   N segment lists, one per supported core count
+3. Runtime dispatch in `orknn_own_run` that picks the right segment
+   list based on `ctx->core_mask` at submit time
+
+Issue [#60][i60] tracks this; reproduction of the vendor's exact
+submit pattern is captured in the task 10.1 artifacts at the end of
+this PR's commit message.
+
+### Gap that remains
+
+Until Phase 2 lands, openrknn gives up **1.31×–1.87× on 4 of 5
+runtime models** when the caller asks for multi-core:
+
+| Model      | vendor 1c | vendor 3c | openrknn (1c fallback) | gap    |
+|------------|----------:|----------:|-----------------------:|-------:|
+| MBv1       |  1.98 ms  |  1.04 ms  |                1.95 ms | +87%   |
+| ResNet50   |  9.13 ms  |  6.91 ms  |                9.08 ms | +31%   |
+| YOLOv5     | 18.61 ms  | 12.58 ms  |               18.47 ms | +47%   |
+| YOLOv8     | 16.29 ms  | 16.35 ms  |               16.09 ms |  −1%   |
+| DeepLabv3  | 28.85 ms  | 18.95 ms  |               28.79 ms | +52%   |
+
+YOLOv8 is the only model where even the vendor sees no benefit from
+multi-core (its compiled pattern doesn't parallelise), so openrknn's
+fallback is already at parity.
 
 ## How to reproduce
 

--- a/openrknn/src/openrknn.h
+++ b/openrknn/src/openrknn.h
@@ -324,7 +324,7 @@ void orknn_bo_destroy(int fd, struct orknn_bo *bo);
 int  orknn_bo_sync_to_device(int fd, struct orknn_bo *bo);
 int  orknn_bo_sync_from_device(int fd, struct orknn_bo *bo);
 int  orknn_npu_submit(int fd, struct orknn_bo *task_bo,
-                      struct orknn_segment *seg);
+                      struct orknn_segment *seg, uint32_t core_mask);
 
 /* ======================================================================
  * Own implementations (phases 2-6)

--- a/openrknn/src/openrknn_drm.c
+++ b/openrknn/src/openrknn_drm.c
@@ -7,6 +7,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <string.h>
+#include <stdlib.h>
 #include <errno.h>
 #include <sys/ioctl.h>
 #include <sys/mman.h>
@@ -259,22 +260,71 @@ int orknn_bo_sync_from_device(int fd, struct orknn_bo *bo)
  * ====================================================================== */
 
 int orknn_npu_submit(int fd, struct orknn_bo *task_bo,
-                     struct orknn_segment *seg)
+                     struct orknn_segment *seg, uint32_t core_mask)
 {
+    /* Normalise the user-requested core mask.
+     *
+     * RKNN_NPU_CORE_0 = 0x1 (core 0 only)
+     * RKNN_NPU_CORE_1 = 0x2 (core 1 only)
+     * RKNN_NPU_CORE_2 = 0x4 (core 2 only)
+     * RKNN_NPU_CORE_0_1   = 0x3, 0_2 = 0x5, 1_2 = 0x6
+     * RKNN_NPU_CORE_0_1_2 = 0x7 (all 3 cores)
+     * RKNN_NPU_CORE_AUTO  = 0x0 (kernel picks core 0 by default for us)
+     *
+     * Multi-core (popcount > 1) requires per-core-count pre-compiled
+     * task BO layouts that openrknn doesn't yet parse from the .rknn
+     * — each core needs its own {sc_start, sc_count} region in
+     * subcore_task[2..4], and those regions live at task BO offsets
+     * that differ from our single-core fb_build_segments output. See
+     * issue #60 for the full scope. For now we fall back to single
+     * core 0 when the user asks for multi-core, with a one-time
+     * warning, unless ORKNN_ALLOW_MULTICORE=1 is set (experimental).
+     */
+    uint32_t effective = core_mask & 0x7;
+    int popcount = __builtin_popcount(effective);
+    if (popcount > 1 && !getenv("ORKNN_ALLOW_MULTICORE")) {
+        static int warned = 0;
+        if (!warned) {
+            orknn_log(0, "drm: core_mask=0x%x (multi-core) not yet "
+                         "supported in OWN mode — falling back to "
+                         "core 0 only. See issue #60. Set "
+                         "ORKNN_ALLOW_MULTICORE=1 to force submit "
+                         "anyway (may hang or produce wrong output).",
+                      effective);
+            warned = 1;
+        }
+        effective = 0x1;
+        popcount = 1;
+    }
+    if (effective == 0)
+        effective = 0x1;  /* AUTO → core 0 */
+
     struct rknpu_submit sub = {
         .flags = seg->flags | RKNPU_JOB_BLOCK,
         .timeout = 6000,
         .task_start = seg->sc_start,
         .task_number = seg->task_number,
         .task_obj_addr = task_bo->obj_addr,
-        .core_mask = 0x0, /* auto — matches proxy */
+        .core_mask = effective,
         .fence_fd = -1,
         .subcore_task = {
-            { seg->sc_start, seg->sc_count },
-            { seg->sc_start, seg->sc_count },
-            { seg->sc_start, seg->sc_count },
-            { seg->sc_start, seg->sc_count },
-            { seg->sc_start, seg->sc_count },
+            /* Single-core: kernel reads subcore_task[core_index] where
+             * core_index is the bit position of the active core. We
+             * populate all 3 single-core slots with the same range so
+             * mask=0x1, 0x2, 0x4 all work.
+             *
+             * Multi-core (experimental): slots [2..4] would need to
+             * carry per-core task regions from a multi-core task BO
+             * layout we don't yet parse. Filled with the same
+             * single-core range; kernel will either run all 3 cores
+             * on redundant work (wasteful + incorrect output) or
+             * error out. */
+            { seg->sc_start, seg->sc_count },  /* [0] mask=0x1 → core 0 */
+            { seg->sc_start, seg->sc_count },  /* [1] mask=0x2 → core 1 */
+            { seg->sc_start, seg->sc_count },  /* [2] mask=0x4 → core 2
+                                                *     (and 3-core: core 0) */
+            { seg->sc_start, seg->sc_count },  /* [3] 3-core: core 1 */
+            { seg->sc_start, seg->sc_count },  /* [4] 3-core: core 2 */
         },
     };
 

--- a/openrknn/src/openrknn_run.c
+++ b/openrknn/src/openrknn_run.c
@@ -1379,7 +1379,8 @@ int orknn_own_run(struct orknn_context *ctx, rknn_run_extend *extend)
      * slice into the NPU. No per-cycle rewrites needed (see task 9.4). */
     for (uint32_t i = 0; i < max_segs; i++) {
         struct orknn_segment *seg = &m->segments[i];
-        int ret = orknn_npu_submit(ctx->npu_fd, &ctx->task_bo, seg);
+        int ret = orknn_npu_submit(ctx->npu_fd, &ctx->task_bo, seg,
+                                   ctx->core_mask);
         if (ret) {
             orknn_log(0, "run: segment %u submit failed", i);
             return RKNN_ERR_FAIL;


### PR DESCRIPTION
## Summary

- Plumbs `ctx->core_mask` from `rknn_set_core_mask` through to the
  RKNPU ioctl submit descriptor, replacing the hardcoded `0x0`.
- Single-core masks (0x1/0x2/0x4) now route work to the requested
  core. Multi-core masks (0x3/0x5/0x6/0x7) print a one-time
  warning and fall back to Core 0.
- Documents the full multi-core scope in `docs/benchmarks.md` —
  turns out the .rknn task BO contains **separate pre-compiled
  regions per core count**, so true multi-core is more than a
  1-line fix.

## What the investigation found

Captured the vendor's exact submit descriptor for mobilenet_v1 in
all 5 core_mask configurations using a patched `intercept_swap.so`
that dumps all 5 `subcore_task[]` slots. Observations:

1. **Single-core is easy**: all three slots `sc[0..2]` contain the
   same `(sc_start, sc_count)` — the kernel reads
   `subcore_task[core_index]` so slot 0 works for mask=0x1, slot 1
   for 0x2, slot 2 for 0x4. openrknn's existing fb_build_segments
   output fits this perfectly once the hardcoded 0x0 is removed.

2. **Multi-core uses different task BO regions.** For mbv1's 307
   total tasks:

   | Region | Size | Purpose |
   |--------|------|---------|
   | 0–50   | 51 | single-core layout |
   | 51–131 | 81 | dual-core layout  |
   | 133–236 | 104 | triple-core layout |
   | 237–306 | 70  | warmup/iter replicas |

3. **Kernel reads `subcore_task[core_index + 2]` for 3-core mode**
   (slots [2..4], not [0..2]). Confirmed in
   `rknpu-driver/rknpu_job.c:320-330`.

4. The RKNN toolkit bakes these per-core-count layouts into the
   .rknn at compile time. Runtime just picks offsets. openrknn's
   current `fb_build_segments` only derives the single-core region
   from the FB operator graph — adding multi-core is a separate
   RE project (updated scope in #60).

## Hardware verification

```
mask=0x1 → NPU load: Core0: 99%, Core1: 0%, Core2: 0%
mask=0x2 → NPU load: Core0:  0%, Core1: 93%, Core2: 0%
mask=0x4 → NPU load: Core0:  0%, Core1: 0%, Core2: 99%
mask=0x7 → Core0: 99% (fallback + warning)
```

## Benchmark (unchanged from master, confirms no regression)

| Model | vendor 1c | openrknn 1c | gap |
|---|---:|---:|---:|
| mobilenet_v1 | 1.98 ms | 1.95 ms | −1.5% |
| resnet50 | 9.13 ms | 9.08 ms | −0.5% |
| yolov5 | 18.61 ms | 18.47 ms | −0.7% |
| yolov8 | 16.29 ms | 16.09 ms | −1.3% |
| deeplabv3 | 28.85 ms | 28.79 ms | −0.2% |

## Test plan

- [x] ci_validate.sh: Phase 1 (vendor baseline), Phase 2 (OWN path),
      Phase 2.5 (byte-exact regcmd diff), Phase 3 (proxy) all pass 7/7
- [x] Core selection verified via `/sys/kernel/debug/rknpu/load`
      while running mobilenet_v1 inference at each mask
- [x] Multi-core fallback: mask=0x7 latency matches mask=0x1 (fallback
      triggered), no hangs, no wrong outputs
- [x] `openrknn-segments-verify` gate unchanged

## Follow-up

- #60 remains open with the updated scope — now labeled with the
  specific RE work needed (task BO layout parsing per core count)
- The captured vendor submit patterns live in the commit body for
  anyone picking up #60 as a concrete starting point

🤖 Generated with [Claude Code](https://claude.com/claude-code)