### PR TITLE
openrknn: pad w_stride to 16 elements for NHWC inputs

### DIFF
--- a/openrknn/src/openrknn_model.c
+++ b/openrknn/src/openrknn_model.c
@@ -337,13 +337,13 @@ static void parse_tensor_json(const char *obj, struct orknn_tensor_info *ti,
         ti->n_elems *= ti->dims[i];
     ti->size = ti->n_elems * dtype_size(ti->type);
 
-    /* w_stride = width dimension for 4D tensors */
-    if (ti->n_dims == 4) {
-        if (ti->fmt == RKNN_TENSOR_NHWC)
-            ti->w_stride = ti->dims[2]; /* W */
-        else
-            ti->w_stride = ti->dims[3]; /* W for NCHW */
-    }
+    /* w_stride: for NHWC 4D tensors the vendor reports W padded up to
+     * the next multiple of 16 (e.g. deeplabv3 513 → 528, lprnet 94 →
+     * 96). For NCHW 4D tensors the vendor reports 0. */
+    if (ti->n_dims == 4 && ti->fmt == RKNN_TENSOR_NHWC)
+        ti->w_stride = (ti->dims[2] + 15) & ~15u;
+    else
+        ti->w_stride = 0;
 
     /* size_with_stride: for now same as size */
     ti->size_with_stride = ti->size;
@@ -559,9 +559,12 @@ static void extract_fb_tensor_info(const uint8_t *fb, uint32_t tensor_table_fpos
      * incorrectly on YOLOv5 because the native_dims was stale from
      * parse_tensor_json's c2=16 assumption. */
 
-    /* w_stride: set for NHWC 4D tensors only. */
+    /* w_stride: for NHWC 4D tensors the vendor reports W padded up to
+     * the next multiple of 16 (e.g. deeplabv3 input 513 → 528, lprnet
+     * 94 → 96; mobilenet_v1 224 and yolov5 640 already 16-aligned).
+     * For NCHW 4D tensors and non-4D tensors the vendor reports 0. */
     if (ti->n_dims == 4 && ti->fmt == RKNN_TENSOR_NHWC)
-        ti->w_stride = ti->dims[2]; /* W */
+        ti->w_stride = (ti->dims[2] + 15) & ~15u;
     else
         ti->w_stride = 0;
 


### PR DESCRIPTION
## Summary

Closes #71. The vendor `librknnrt.so` reports `rknn_tensor_attr.w_stride` as the input W dimension **aligned up to the next multiple of 16**. openrknn was returning raw W, which caused a byte-level MISMATCH at offset 360 of the struct on deeplabv3 (513 vs 528) and would also trigger on lprnet (94 vs 96) if its input attr were queried.

The check across all 7 ground-truth models:

| Model          | W  | vendor w_stride | openrknn (before) | openrknn (after) |
|----------------|---:|----------------:|------------------:|-----------------:|
| mobilenet_v1   | 224 | 224 | 224 | 224 |
| resnet50       | 224 | 224 | 224 | 224 |
| yolov5         | 640 | 640 | 640 | 640 |
| yolov8         | 640 | 640 | 640 | 640 |
| deeplabv3      | 513 | **528** | 513 | **528** |
| mobilesam_encoder | 448 | 448 | 448 | 448 |
| lprnet         |  94 | **96**  |  94 | **96**  |

`size_with_stride` was already correct because openrknn pulls it from the FlatBuffer `f[12]` field, which stores the padded allocation size (`N*H*align(W,16)*C*dtype_size` = 812592 for deeplabv3).

## Fix

Both w_stride-setting sites (`fill_tensor_from_fb` and the JSON fallback `parse_tensor_json`) now compute `(W + 15) & ~15` for NHWC 4D tensors and 0 otherwise.

## Test plan

- [x] Byte-by-byte compare openrknn vs vendor `rknn_tensor_attr` for all 7 models — match
- [x] `tests/ci_validate.sh` → 7/7 pass
- [x] MISMATCH log is silent on deeplabv3 query path

🤖 Generated with [Claude Code](https://claude.com/claude-code)