### PR TITLE
openrknn: fix pc2/pc3 LUT blob assignment for transformer models

### DIFF
--- a/openrknn/src/openrknn_run.c
+++ b/openrknn/src/openrknn_run.c
@@ -449,15 +449,27 @@ static void patch_regcmd_addresses(struct orknn_context *ctx)
                 pc3_off = closer_off;
                 pc2_off = farther_off;
             } else {
-                /* Gap between closer and rc_off → closer is PC2.
-                 * NOTE: this is WRONG for SmolVLM l0_mlp (oracle shows
-                 * the assignment should be swapped). But changing it
-                 * breaks DeepLabv3 which relies on this convention.
-                 * The 20 resulting pc2/pc3 diffs on l0_mlp affect
-                 * per-channel correction (em=0x60) quality but don't
-                 * crash the NPU. Tracked as a follow-up. */
-                pc2_off = closer_off;
-                pc3_off = farther_off;
+                /* Gap between closer and rc_off. For CNN models
+                 * (DeepLabv3), closer=PC2 and farther=PC3. For
+                 * transformer models (SmolVLM, exNorm ops present),
+                 * the assignment is swapped: closer=PC3, farther=PC2.
+                 * Detect via presence of exNorm ops in the op table. */
+                int has_exnorm = 0;
+                if (m->ops) {
+                    for (uint32_t oi = 0; oi < m->op_count; oi++) {
+                        if (strncmp(m->ops[oi].type, "exNorm", 6) == 0) {
+                            has_exnorm = 1;
+                            break;
+                        }
+                    }
+                }
+                if (has_exnorm) {
+                    pc3_off = closer_off;
+                    pc2_off = farther_off;
+                } else {
+                    pc2_off = closer_off;
+                    pc3_off = farther_off;
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

- Fix PC LUT blob heuristic: transformer models (exNorm ops present) need swapped pc2/pc3 assignment in the gap case vs CNN models
- Eliminates 20 PPU em=0x60 DMA-class diffs on SmolVLM l0_mlp (72 → 52 remaining)

## Context

The pc2/pc3 heuristic picks two 1024-byte type-6 blobs closest to the regcmd offset. For the "gap" case (closer blob doesn't touch rc_off), CNN models need closer=pc2 and transformer models need closer=pc3. Detection: check for exNorm ops in the op table.

This was tracked as a known follow-up in the source comments since PR #83.

## Remaining 52 diffs (not addressed here)

- 26 exNorm REFORMAT activation routing diffs (SRC/DST use wrong act tensor offsets)  
- 24 BS/BN blob diffs (template emits gamma/beta for exNorm REFORMATs, oracle has 0)
- 2 input/output BO routing diffs

These require activation memory plan analysis and are tracked on #80.

## Test plan

- [x] CI: 9/9 pass
- [x] Phase 2.5: 5/5 CNN byte-exact, 0 gating
- [x] SmolVLM l0_mlp: runs, DMA-class diffs reduced 72 → 52
- [x] 24/24 shards still run without crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)