### PR TITLE
openrknn: unified activation BO for FP16 transformers

### DIFF
--- a/openrknn/src/openrknn.h
+++ b/openrknn/src/openrknn.h
@@ -331,6 +331,11 @@ struct orknn_context {
      * 1 = NCHW (c-major: dst[c*H*W + h*W + w])
      * Detected during sig search by trying both interpretations. */
     uint8_t  act_output_src_order[16];
+    /* Unified activation BO: when set, input/output tensors are embedded
+     * in the activation BO at their f[13] offsets. DMA address resolution
+     * uses act_base for in_base/out_base instead of separate I/O BOs.
+     * Matches vendor's BO layout (3 BOs: task + weight + unified act). */
+    int unified_act;
     /* Logging */
     int log_level;
 };

--- a/openrknn/src/openrknn_input.c
+++ b/openrknn/src/openrknn_input.c
@@ -165,7 +165,30 @@ int orknn_own_inputs_set(struct orknn_context *ctx, uint32_t n_inputs,
 
         orknn_bo_sync_to_device(ctx->npu_fd, bo);
 
-        orknn_log(2, "inputs_set: input[%u] %u bytes -> BO dma=0x%lx + act BO",
+        /* Unified activation BO: also copy input data into the activation BO
+         * at the subgraph input tensor's f[13] offset. The vendor's regcmd
+         * template reads input from the activation BO, not a separate BO. */
+        if (ctx->unified_act && ctx->activation_bo.map && m->tensor_offsets) {
+            /* Find subgraph input tensor index from the input-consuming op */
+            uint32_t sg_in_tidx = 0;
+            if (m->ops && m->input_consuming_op_idx < m->op_count) {
+                const struct orknn_op_info *ico = &m->ops[m->input_consuming_op_idx];
+                if (ico->input_count > 0)
+                    sg_in_tidx = ico->input_tensors[0];
+            }
+            uint32_t act_off = (sg_in_tidx < m->tensor_count) ?
+                               m->tensor_offsets[sg_in_tidx] : 0;
+            uint32_t copy_size = bo->size;
+            if (act_off + copy_size <= ctx->activation_bo.size) {
+                memcpy((uint8_t *)ctx->activation_bo.map + act_off,
+                       bo->map, copy_size);
+                orknn_bo_sync_to_device(ctx->npu_fd, &ctx->activation_bo);
+                orknn_log(1, "inputs_set: unified copy %u bytes -> act+0x%x",
+                          copy_size, act_off);
+            }
+        }
+
+        orknn_log(2, "inputs_set: input[%u] %u bytes -> BO dma=0x%lx",
                   idx, inputs[i].size, (unsigned long)bo->dma_addr);
     }
 

--- a/openrknn/src/openrknn_memory.c
+++ b/openrknn/src/openrknn_memory.c
@@ -145,6 +145,12 @@ int orknn_alloc_model_bos(struct orknn_context *ctx)
                 act_size = (uint32_t)new_sz;
             }
         }
+        /* When activation size multiplier is set, enable unified activation
+         * BO layout: input/output data is embedded in the activation BO at
+         * their FB f[13] tensor offsets, matching the vendor's 3-BO layout.
+         * This is required for FP16 transformer models where the vendor's
+         * regcmd template assumes input/output live in the activation BO. */
+        ctx->unified_act = 1;
     }
     orknn_log(1, "memory: activation size: scan=%u+largest_io=%u "
                  "sentinels=%u -> %u",

--- a/openrknn/src/openrknn_model.c
+++ b/openrknn/src/openrknn_model.c
@@ -826,6 +826,7 @@ static void parse_fb_tensor_offsets(const uint8_t *fb, struct orknn_model *m)
         weight_blob[i] = 0xFFFFFFFFu; /* sentinel: not a weight */
 
     uint32_t nonzero_off = 0, have_blob = 0;
+    int dump_fields = (getenv("ORKNN_DEBUG_FB_TENSORS") != NULL);
     for (uint32_t i = 0; i < n_tensors; i++) {
         uint32_t t = orknn_fb_vec_at(fb, tensors_fpos, i);
         if (!t) continue;
@@ -834,6 +835,18 @@ static void parse_fb_tensor_offsets(const uint8_t *fb, struct orknn_model *m)
             uint32_t v = orknn_fb_u32(fb, f13);
             offsets[i] = v;
             if (v) nonzero_off++;
+        }
+        if (dump_fields) {
+            /* Dump fields 0..20 for RE diagnosis */
+            for (int fi = 0; fi <= 20; fi++) {
+                uint32_t fp = orknn_fb_field(fb, t, fi);
+                if (fp) {
+                    uint32_t v = orknn_fb_u32(fb, fp);
+                    if (v != 0)
+                        orknn_log(0, "tensor[%u] f[%d] = 0x%x (%u)",
+                                  i, fi, v, v);
+                }
+            }
         }
         /* f[18] = weight_data blob index for weight/bias tensors.
          * Present and non-zero only for tensors whose data is stored as

--- a/openrknn/src/openrknn_run.c
+++ b/openrknn/src/openrknn_run.c
@@ -170,8 +170,16 @@ static void patch_regcmd_addresses(struct orknn_context *ctx)
 
     uint32_t wt_base = (uint32_t)ctx->weight_bo.dma_addr;
     uint32_t act_base = (uint32_t)ctx->activation_bo.dma_addr;
-    uint32_t in_base = ctx->input_bos ? (uint32_t)ctx->input_bos[0].dma_addr : 0;
-    uint32_t out_base = ctx->output_bos ? (uint32_t)ctx->output_bos[0].dma_addr : 0;
+    uint32_t in_base, out_base;
+    if (ctx->unified_act) {
+        /* Unified BO layout: input/output live inside the activation BO
+         * at their tensor f[13] offsets. No separate I/O base addresses. */
+        in_base = act_base;
+        out_base = act_base;
+    } else {
+        in_base = ctx->input_bos ? (uint32_t)ctx->input_bos[0].dma_addr : 0;
+        out_base = ctx->output_bos ? (uint32_t)ctx->output_bos[0].dma_addr : 0;
+    }
 
     /* Dev: ORKNN_DUMP_BO1_PRE dumps the pre-patch weight BO. Used with
      * tests/diff_regcmd.py to compare vendor's post-init oracle against
@@ -743,6 +751,13 @@ static void patch_regcmd_addresses(struct orknn_context *ctx)
                 orknn_log(0, "  in[%u] tidx=%u blob=%u "
                           "wt_off=0x%x act_off=0x%x",
                           j, tidx, blob_idx, bo_off, act_off);
+            }
+            for (uint32_t j = 0; j < op->output_count && j < 4; j++) {
+                uint32_t tidx = op->output_tensors[j];
+                uint32_t act_off = (tidx < m->tensor_count) ?
+                    m->tensor_offsets[tidx] : UINT32_MAX;
+                orknn_log(1, "  out[%u] tidx=%u act_off=0x%x",
+                          j, tidx, act_off);
             }
         }
     }
@@ -1551,9 +1566,11 @@ static void patch_regcmd_addresses(struct orknn_context *ctx)
                     new_val = act_base + scratch_off + val;
                     do_patch = 1;
                 } else if (dst_is_sg_output && sg_out_bo_idx >= 0 &&
-                    (uint32_t)sg_out_bo_idx < m->n_outputs) {
+                    (uint32_t)sg_out_bo_idx < m->n_outputs &&
+                    !ctx->unified_act) {
                     /* Writing to a subgraph output tensor: target the
-                     * corresponding output BO directly. */
+                     * corresponding output BO directly. In unified mode,
+                     * output lives in the activation BO at dst_tensor_off. */
                     new_val = (uint32_t)ctx->output_bos[sg_out_bo_idx]
                                   .dma_addr + val;
                     do_patch = 1;


### PR DESCRIPTION
## Summary

- Match vendor's 3-BO layout (task + weight + unified activation) for FP16 transformer models
- When `ORKNN_ACT_SIZE_MULT` is set, input/output DMA addresses resolve through the activation BO instead of separate I/O BOs
- Input data is copied into the activation BO at the subgraph input tensor's f[13] offset
- Eliminates 4 input/output routing DMA diffs (52 → 48 remaining on l0_mlp)

## Context

Root cause analysis found that the vendor embeds input/output tensors inside a single 28MB activation BO, while openrknn used separate BOs. The regcmd template assumes unified layout, causing DMA address mismatches.

Remaining 48 diffs are from the vendor's **lifetime-based memory overlap** optimization where it places exNorm output at 0x600000 (overlapping dead scratch tensor range [0x480000, 0x790040)) instead of the FB's conservative 0x790040. This requires implementing the vendor's memory planner — tracked separately.

## Test plan

- [x] CI: 9/9 pass, 5/5 CNN byte-exact
- [x] SmolVLM l0_mlp: runs, DMA diffs 52 → 48
- [x] CNN models unaffected (unified_act disabled by default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)